### PR TITLE
remove haskell98 dependency

### DIFF
--- a/Text/Search/Sphinx.hs
+++ b/Text/Search/Sphinx.hs
@@ -28,7 +28,7 @@ import qualified Data.ByteString.Lazy as BS (ByteString,
 import Data.Int (Int64)
 
 import Network (connectTo, PortID(PortNumber))
-import IO (Handle, hFlush)
+import System.IO (Handle, hFlush)
 import Data.Bits ((.|.))
 
 import Prelude hiding (filter, tail)

--- a/sphinx.cabal
+++ b/sphinx.cabal
@@ -1,5 +1,5 @@
 Name:            sphinx
-Version:         0.4.0.3
+Version:         0.4.0.5
 Synopsis:        Haskell bindings to the Sphinx full-text searching deamon.
 Description:     Haskell bindings to the Sphinx full-text searching deamon. Compatible with sphinx version 1.1
 Category:        Text, Search, Database
@@ -19,5 +19,6 @@ Other-Modules:   Text.Search.Sphinx.Get, Text.Search.Sphinx.Put
 Build-Type:      Simple
 Build-Depends:   base >= 4 && < 5,
                  binary, data-binary-ieee754,
-                 bytestring, network, haskell98,
+                 bytestring, network,
                  xml, utf8-string >= 0.3
+


### PR DESCRIPTION
this change makes it compile with ghc 7.2
I've bumped the versio number to 0.4.0.5 because 0.4.0.4 was already on hackage, even though the version int he repository was only 0.4.0.3
