### PR TITLE
Use (modern version of) network-simple

### DIFF
--- a/sphinx.cabal
+++ b/sphinx.cabal
@@ -30,9 +30,9 @@ library
 
   Build-Depends:   base >= 4 && < 5,
                    binary, data-binary-ieee754,
-                   bytestring, network,
-                   xml, 
-                   text < 1.3, text-icu < 0.8
+                   bytestring, network-simple,
+                   xml, exceptions,
+                   text, text-icu
 
   if flag(version-1-1-beta)
     cpp-options:   -DONE_ONE_BETA


### PR DESCRIPTION
The library depended on an old version of the `network` library. This updates the code to a recent version of `network-simple`.