### PR TITLE
Support ranking = expr

### DIFF
--- a/Text/Search/Sphinx.hs
+++ b/Text/Search/Sphinx.hs
@@ -28,6 +28,7 @@ import qualified Text.Search.Sphinx.Types as T (
   QueryStatus(..), toStatus, Status(..),
   SingleResult(..), Result(..), QueryResult(..))
 
+import Text.Search.Sphinx.Types ( Rank(..) )
 import Text.Search.Sphinx.Configuration (Configuration(..), defaultConfig)
 import qualified Text.Search.Sphinx.ExcerptConfiguration as ExConf (ExcerptConfiguration(..))
 import Text.Search.Sphinx.Get (times, getResult, readHeader, getStr, getTxt)
@@ -282,7 +283,12 @@ serializeQuery cfg conv (T.Query qry indexes comment) = do
              , limit
              , fromEnum . mode
              , fromEnum . ranker
-             , fromEnum . sort]
+             ]
+    case ranker cfg of
+      RankExpr -> str (rankExpr cfg)
+      _        -> pure ()
+
+    num (fromEnum (sort cfg))
     str (sortBy cfg)
     txt conv qry
     list num (weights cfg)

--- a/Text/Search/Sphinx/Configuration.hs
+++ b/Text/Search/Sphinx/Configuration.hs
@@ -35,6 +35,8 @@ data Configuration = Configuration {
   , mode :: T.MatchMode
     -- | Ranking mode
   , ranker :: T.Rank
+    -- | Ranking expression, used when ranker = RankExpr
+  , rankExpr :: String
     -- | Match sorting mode
   , sort :: T.Sort
     -- | Attribute to sort by
@@ -82,6 +84,7 @@ defaultConfig = Configuration {
                 , limit         = 20
                 , mode          = T.All
                 , ranker        = T.ProximityBm25
+                , rankExpr      = ""
                 , sort          = T.Relevance
                 , sortBy        = ""
                 , minId         = 0

--- a/Text/Search/Sphinx/Types.hs
+++ b/Text/Search/Sphinx/Types.hs
@@ -86,6 +86,7 @@ data Rank = ProximityBm25  -- default mode, phrase proximity major factor and BM
           | MatchAny       -- internaly used to emulate SPHINX_MATCH_ANY searching mode
           | Fieldmask      -- ?
           | Sph04          -- like ProximityBm25, but more weight given to matches at beginning or end of field
+          | RankExpr       -- Custom expression, set with rankExpr
           | Total
           deriving (Show, Enum)
 


### PR DESCRIPTION
This MR adds support for expressions in a ranking function, and the implementation is a straightforward translation of the [PHP version](https://github.com/gigablah/sphinxphp/blob/2.0.8/src/Sphinx/SphinxClient.php#L1223). This should also fix the `Total` support, I have not actually tested that out, but the enum value was not the same as in the PHP client so I am quite certain this is an improvement in that regard as well.